### PR TITLE
Bump PHP Version

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.4, 7.3, 7.2]
+        php: [8.0, 7.4, 7.3, 7.2]
         laravel: [8.*, 7.*, 6.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2 || ^8.0",
         "guzzlehttp/guzzle": "^6.3 || ^7.0",
         "illuminate/support": "^6.0 || ^7.0 || ^8.0"
     },


### PR DESCRIPTION
Currently the tag 2.2.0 does not support PHP8.

fixes #7 

currently shows:
```bash
$ composer update
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - astrotomic/laravel-guzzle[2.1.0, ..., 2.2.0] require php ^7.2 -> your php version (8.0.7) does not satisfy that requirement.
    - elbgoods/laravel-trashmail-rule 0.9.0 requires astrotomic/laravel-guzzle ^2.1 -> satisfiable by astrotomic/laravel-guzzle[2.1.0, 2.2.0].
    - Root composer.json requires elbgoods/laravel-trashmail-rule ^0.9.0 -> satisfiable by elbgoods/laravel-trashmail-rule[0.9.0].
```

Please create a new php-8 release ;)

all the best
max